### PR TITLE
Fixed sync dispatch

### DIFF
--- a/src/Avalonia.FuncUI.Elmish/Library.fs
+++ b/src/Avalonia.FuncUI.Elmish/Library.fs
@@ -8,10 +8,13 @@ open Avalonia.Threading
 module Program =
 
     let private syncDispatch (dispatch: Dispatch<'msg>) : Dispatch<'msg> =
-        match Dispatcher.UIThread.CheckAccess() with
-        | true -> fun msg -> Dispatcher.UIThread.Post (fun () -> dispatch msg)
-        | false -> fun msg -> dispatch msg
-    
+        fun msg ->
+            let checkAccess = Dispatcher.UIThread.CheckAccess()
+            if checkAccess then
+                dispatch msg
+            else
+                Dispatcher.UIThread.Post (fun () -> dispatch msg)
+
     let withHost (host: IViewHost) (program: Program<'arg, 'model, 'msg, #IView>) =
         let setState state dispatch =
             let view = ((Program.view program) state dispatch)


### PR DESCRIPTION
CheckAccess works all the way around. Access check should be after receiving the message as we don't know from which source we got it.