### PR TITLE
Two subscriptions considered different if either of them captures state

### DIFF
--- a/src/Avalonia.FuncUI.UnitTests/LibTests.fs
+++ b/src/Avalonia.FuncUI.UnitTests/LibTests.fs
@@ -1,6 +1,9 @@
 ﻿namespace Avalonia.FuncUI.UnitTests
 
+open System
+open System.Threading
 open Avalonia.FuncUI.Library
+open Avalonia.FuncUI.Types
 open Xunit
 
 module Library =
@@ -46,3 +49,41 @@ module Library =
         Assert.True(FunctionAnalysis.cache.ContainsKey(a.GetType()))
         Assert.True(FunctionAnalysis.cache.ContainsKey(b.GetType()))
         ()
+
+    [<Fact>]
+    let ``subscriptions are different if either of them captures state`` () =
+        let dlgt = Action<_>(ignore)
+        let s1CapturingState = {
+            Subscription.name = "sub"
+            subscribe = fun _ -> new CancellationTokenSource()
+            func = dlgt
+            funcCapturesState = true
+            funcType = typeof<int>
+        }
+        let s2CapturingState = {
+            Subscription.name = "sub"
+            subscribe = fun _ -> new CancellationTokenSource()
+            func = dlgt
+            funcCapturesState = true
+            funcType = typeof<int>
+        }
+        let s1NotCapturingState = {
+            Subscription.name = "sub"
+            subscribe = fun _ -> new CancellationTokenSource()
+            func = dlgt
+            funcCapturesState = false
+            funcType = typeof<int>
+        }
+        let s2NotCapturingState = {
+            Subscription.name = "sub"
+            subscribe = fun _ -> new CancellationTokenSource()
+            func = dlgt
+            funcCapturesState = false
+            funcType = typeof<int>
+        }
+
+        Assert.False(s1CapturingState.Equals(s2CapturingState))
+        Assert.False(s1CapturingState.Equals(s1NotCapturingState))
+        Assert.False(s2CapturingState.Equals(s1CapturingState))
+
+        Assert.True(s1NotCapturingState.Equals(s2NotCapturingState))

--- a/src/Avalonia.FuncUI.UnitTests/Program.fs
+++ b/src/Avalonia.FuncUI.UnitTests/Program.fs
@@ -1,6 +1,10 @@
 namespace Avalonia.FuncUI.UnitTests
 
+open Xunit
+
 module Program =
+    [<assembly: CollectionBehavior(DisableTestParallelization = true)>]
+    do()
 
     let [<EntryPoint>] main _ =
         0

--- a/src/Avalonia.FuncUI/Types.fs
+++ b/src/Avalonia.FuncUI/Types.fs
@@ -75,11 +75,13 @@ module Types =
                 match other with
                 | :? Subscription as other -> 
                     this.name = other.name &&
-                    this.funcType = other.funcType
+                    this.funcType = other.funcType &&
+                    not this.funcCapturesState &&
+                    not other.funcCapturesState
                 | _ -> false
                 
             override this.GetHashCode () =
-                (this.name, this.funcType).GetHashCode()
+                (this.name, this.funcType, this.funcCapturesState).GetHashCode()
                                
     type IAttr =
         abstract member UniqueName : string


### PR DESCRIPTION
Fixed the issue with two subscriptions that capture state to be equal.