### PR TITLE
Update Avalonia to 0.9.9

### DIFF
--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog.fsproj
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog.fsproj
@@ -33,7 +33,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Avalonia.Desktop" Version="0.9.7" />
+      <PackageReference Include="Avalonia.Desktop" Version="0.9.9" />
       <PackageReference Include="Bogus" Version="28.4.1" />
       <PackageReference Update="FSharp.Core" Version="4.7.0" />
     </ItemGroup>

--- a/src/Avalonia.FuncUI.DSL/Avalonia.FuncUI.DSL.fsproj
+++ b/src/Avalonia.FuncUI.DSL/Avalonia.FuncUI.DSL.fsproj
@@ -105,7 +105,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Avalonia.FuncUI\Avalonia.FuncUI.fsproj" />
-      <PackageReference Include="Avalonia.Desktop" Version="0.9.7" />
+      <PackageReference Include="Avalonia.Desktop" Version="0.9.9" />
     </ItemGroup>
 
 </Project>

--- a/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
+++ b/src/Avalonia.FuncUI.Elmish/Avalonia.FuncUI.Elmish.fsproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="0.9.7" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.9.9" />
     <PackageReference Include="Elmish" Version="3.0.6" />
     <PackageReference Update="FSharp.Core" Version="4.6.2" />
   </ItemGroup>

--- a/src/Avalonia.FuncUI.UnitTests/Avalonia.FuncUI.UnitTests.fsproj
+++ b/src/Avalonia.FuncUI.UnitTests/Avalonia.FuncUI.UnitTests.fsproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="0.9.7" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.9.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="0.9.7" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.9.9" />
     <PackageReference Update="FSharp.Core" Version="4.6.2" />
   </ItemGroup>
 

--- a/src/Examples/Examples.ClockApp/Examples.ClockApp.fsproj
+++ b/src/Examples/Examples.ClockApp/Examples.ClockApp.fsproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Desktop" Version="0.9.7" />
+        <PackageReference Include="Avalonia.Desktop" Version="0.9.9" />
         <PackageReference Update="FSharp.Core" Version="4.7.0" />
     </ItemGroup>
 </Project>

--- a/src/Examples/Examples.CounterApp/Counter.fs
+++ b/src/Examples/Examples.CounterApp/Counter.fs
@@ -1,11 +1,9 @@
 namespace Examples.CounterApp
 
 open Avalonia.FuncUI.DSL
-open Avalonia.FuncUI.DSL
 
 module Counter =
     open Avalonia.Controls
-    open Avalonia.FuncUI.DSL
     open Avalonia.Layout
     
     type State = { count : int }

--- a/src/Examples/Examples.CounterApp/Examples.CounterApp.fsproj
+++ b/src/Examples/Examples.CounterApp/Examples.CounterApp.fsproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Desktop" Version="0.9.7" />
+        <PackageReference Include="Avalonia.Desktop" Version="0.9.9" />
         <PackageReference Update="FSharp.Core" Version="4.7.0" />
     </ItemGroup>
 

--- a/src/Examples/Examples.GameOfLife/Examples.GameOfLife.fsproj
+++ b/src/Examples/Examples.GameOfLife/Examples.GameOfLife.fsproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.Desktop" Version="0.9.7" />
+        <PackageReference Include="Avalonia.Desktop" Version="0.9.9" />
         <PackageReference Update="FSharp.Core" Version="4.7.0" />
     </ItemGroup>
 

--- a/src/Examples/Examples.MusicPlayer/Examples.MusicPlayer.fsproj
+++ b/src/Examples/Examples.MusicPlayer/Examples.MusicPlayer.fsproj
@@ -24,13 +24,12 @@
     <ItemGroup />
     
     <ItemGroup>
-        <PackageReference Include="Avalonia.Desktop" Version="0.9.2" />
         <PackageReference Include="VideoLAN.LibVLC.Mac" Version="3.1.3.1" />
         <ProjectReference Include="..\..\Avalonia.FuncUI.DSL\Avalonia.FuncUI.DSL.fsproj" />
         <ProjectReference Include="..\..\Avalonia.FuncUI.Elmish\Avalonia.FuncUI.Elmish.fsproj" />
         <ProjectReference Include="..\..\Avalonia.FuncUI\Avalonia.FuncUI.fsproj" />
-        <PackageReference Include="Avalonia.Desktop" Version="0.9.2" />
-        <PackageReference Include="Citrus.Avalonia" Version="1.2.2" />
+        <PackageReference Include="Avalonia.Desktop" Version="0.9.9" />
+        <PackageReference Include="Citrus.Avalonia" Version="1.2.5" />
         <PackageReference Include="LibVLCSharp" Version="3.4.2" />
         <PackageReference Include="VideoLAN.LibVLC.Windows" Version="3.0.8.1" />
     </ItemGroup>

--- a/src/Examples/Examples.Presso/Examples.Presso.fsproj
+++ b/src/Examples/Examples.Presso/Examples.Presso.fsproj
@@ -9,7 +9,7 @@
         <AvaloniaResource Include="**\*.xaml" />
         <AvaloniaResource Include="Assets\*" />
         
-        <PackageReference Include="Avalonia.Desktop" Version="0.9.7" />
+        <PackageReference Include="Avalonia.Desktop" Version="0.9.9" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
I've noticed that `MusicPlayer` has stale reference of Avalonia (`0.9.2` ) that leads to a crash on start so I decided to update version there and elsewhere as well.