### PR TITLE
Add Drag & Drop and port the Avalonia Drag+Drop demo to FuncUI

### DIFF
--- a/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog.fsproj
+++ b/src/Avalonia.FuncUI.ControlCatalog/Avalonia.FuncUI.ControlCatalog.fsproj
@@ -22,6 +22,7 @@
         <Compile Include="Views\Tabs\DatePickerDemo.fs" />
         <AvaloniaResource Include="Views\Tabs\Styles.xaml" />
         <Compile Include="Views\Tabs\GridPatchDemo.fs" />
+        <Compile Include="Views\Tabs\DragDropDemo.fs" />
         <Compile Include="Views\MainView.fs" />
         
         <Compile Include="Main.fs" />

--- a/src/Avalonia.FuncUI.ControlCatalog/Main.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Main.fs
@@ -40,8 +40,10 @@ type App() =
         | _ -> ()
 
 module Program =
+    open System
     open Avalonia.Logging.Serilog
 
+    [<STAThread>]
     [<EntryPoint>]
     let main(args: string[]) =
         AppBuilder

--- a/src/Avalonia.FuncUI.ControlCatalog/Views/MainView.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/MainView.fs
@@ -79,6 +79,10 @@ module MainView =
                            TabItem.header "Grid patch Demo"
                            TabItem.content (ViewBuilder.Create<GridPatchDemo.Host>([]))
                        ]
+                       TabItem.create [
+                           TabItem.header "Drag+Drop Demo"
+                           TabItem.content (ViewBuilder.Create<DragDropDemo.Host>([]))
+                       ]
                    ]
                ]
             ]

--- a/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/DragDropDemo.fs
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/DragDropDemo.fs
@@ -1,0 +1,116 @@
+namespace Avalonia.FuncUI.ControlCatalog.Views
+
+open System
+open Elmish
+open Avalonia.Controls
+open Avalonia.Input
+open Avalonia.FuncUI
+open Avalonia.FuncUI.DSL
+open Avalonia.FuncUI.Components
+open Avalonia.FuncUI.Elmish
+open Avalonia.Layout
+open Avalonia.Threading
+
+module DragDropDemo =
+    type State =
+        { dropText: string
+          dragText: string
+          dragCount: int }
+
+    let init =
+        { dropText = "Drop some text or files here"
+          dragText = "Drag Me"
+          dragCount = 0 }, Cmd.none
+
+    type Msg =
+        | BeginDrag of PointerPressedEventArgs
+        | Dragged of string
+        | Dropped of string
+
+    let doDrag (e, dragCount) =
+        async {
+            let dragData = DataObject()
+            dragData.Set(DataFormats.Text, sprintf "You have dragged text %d times" dragCount)
+
+            let! result = Dispatcher.UIThread.InvokeAsync<DragDropEffects>
+                              (fun _ -> DragDrop.DoDragDrop(e, dragData, DragDropEffects.Copy)) |> Async.AwaitTask
+            return match result with
+                   | DragDropEffects.Copy -> "The text was copied"
+                   | DragDropEffects.Link -> "The text was linked"
+                   | DragDropEffects.None -> "The drag operation was canceled"
+                   | _ -> "That was unexpected"
+        }
+
+    let update (msg: Msg) (state: State): State * Cmd<_> =
+        match msg with
+        | BeginDrag e ->
+            let dragCount = state.dragCount + 1
+            { state with dragCount = dragCount }, Cmd.OfAsync.perform doDrag (e, dragCount) Dragged
+        | Dragged s -> { state with dragText = s }, Cmd.none
+        | Dropped s -> { state with dropText = s }, Cmd.none
+
+    let view (state: State) (dispatch) =
+        StackPanel.create
+            [ StackPanel.orientation Orientation.Vertical
+              StackPanel.spacing 4.0
+              StackPanel.children
+                  [ TextBlock.create
+                      [ TextBlock.classes [ "h1" ]
+                        TextBlock.text "Drag+Drop" ]
+                    TextBlock.create
+                        [ TextBlock.classes [ "h2" ]
+                          TextBlock.text "Example of Drag+Drop capabilities" ]
+                    StackPanel.create
+                        [ StackPanel.orientation Orientation.Horizontal
+                          StackPanel.margin (0.0, 16.0, 0.0, 0.0)
+                          StackPanel.horizontalAlignment HorizontalAlignment.Center
+                          StackPanel.spacing 16.0
+                          StackPanel.children
+                              [ Border.create
+                                  [ Border.classes [ "drag" ]
+                                    Border.borderThickness 2.0
+                                    Border.padding 16.0
+                                    Border.child (TextBlock.create [ TextBlock.text state.dragText ])
+                                    Border.onPointerPressed (BeginDrag >> dispatch) ]
+                                Border.create
+                                    [ Border.classes [ "drop" ]
+                                      Border.padding 16.0
+                                      DragDrop.allowDrop true
+                                      Border.child
+                                          (TextBlock.create
+                                              [ TextBlock.text state.dropText
+                                                DragDrop.onDrop (fun e ->
+                                                    if e.Data.Contains(DataFormats.Text) then
+                                                        Dropped(e.Data.GetText()) |> dispatch
+                                                    elif e.Data.Contains(DataFormats.FileNames) then
+                                                        Dropped
+                                                            (e.Data.GetFileNames() |> String.concat Environment.NewLine)
+                                                        |> dispatch
+                                                    )
+                                                DragDrop.onDragOver (fun e ->
+                                                    e.DragEffects <-
+                                                        if e.Data.Contains(DataFormats.Text)
+                                                           || e.Data.Contains(DataFormats.FileNames) then
+                                                            e.DragEffects
+                                                            &&& (DragDropEffects.Copy ||| DragDropEffects.Link)
+                                                        else
+                                                            DragDropEffects.None) ]) ] ] ] ] ]
+
+
+    type Host() as this =
+        inherit Hosts.HostControl()
+        do
+            this.Styles.Load "avares://Avalonia.FuncUI.ControlCatalog/Views/Tabs/Styles.xaml"
+
+            /// we use this function because sometimes we dispatch messages
+            /// from another thread
+            let syncDispatch (dispatch: Dispatch<'msg>): Dispatch<'msg> =
+                match Dispatcher.UIThread.CheckAccess() with
+                | true -> fun msg -> Dispatcher.UIThread.Post(fun () -> dispatch msg)
+                | false -> dispatch
+
+            Elmish.Program.mkProgram (fun () -> init) update view
+            |> Program.withHost this
+            |> Program.withSyncDispatch syncDispatch
+            |> Program.withConsoleTrace
+            |> Program.run

--- a/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/Styles.xaml
+++ b/src/Avalonia.FuncUI.ControlCatalog/Views/Tabs/Styles.xaml
@@ -12,4 +12,19 @@
     <Style Selector="Button:pointerover">
         <Setter Property="Background" Value="#1abc9c"/>
     </Style>
+
+    <Style Selector="TextBlock.h1">
+        <Setter Property="FontSize" Value="{DynamicResource FontSizeLarge}"/>
+        <Setter Property="FontWeight" Value="Medium"/>
+    </Style>
+    <Style Selector="TextBlock.h2">
+        <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}"/>
+    </Style>
+
+    <Style Selector="Border.drag">
+        <Setter Property="Background" Value="{DynamicResource ThemeAccentBrush}"/>
+    </Style>
+    <Style Selector="Border.drop">
+        <Setter Property="Background" Value="{DynamicResource ThemeAccentBrush2}"/>
+    </Style>
 </Styles>

--- a/src/Avalonia.FuncUI.DSL/Avalonia.FuncUI.DSL.fsproj
+++ b/src/Avalonia.FuncUI.DSL/Avalonia.FuncUI.DSL.fsproj
@@ -74,6 +74,7 @@
         <Compile Include="ComboBoxItem.fs" />
         <Compile Include="CheckBox.fs" />
         <Compile Include="Carousel.fs" />
+        <Compile Include="DragDrop.fs" />
         <Compile Include="Image.fs" />
         <Compile Include="ListBox.fs" />
         <Compile Include="RangeBase.fs" />

--- a/src/Avalonia.FuncUI.DSL/DragDrop.fs
+++ b/src/Avalonia.FuncUI.DSL/DragDrop.fs
@@ -1,0 +1,30 @@
+namespace Avalonia.FuncUI.DSL
+
+[<AutoOpen>]
+module DragDrop =
+    open Avalonia.Controls
+    open Avalonia.Input
+    open Avalonia.Interactivity
+    open Avalonia.FuncUI.Builder
+    open Avalonia.FuncUI.Types
+
+    type DragDrop with
+
+        static member onDragEnter<'t when 't :> Control> (func: DragEventArgs -> unit, ?subPatchOptions) =
+            AttrBuilder<'t>.CreateSubscription<DragEventArgs>
+                (DragDrop.DragEnterEvent, func, ?subPatchOptions = subPatchOptions)
+
+        static member onDragLeave<'t when 't :> Control> (func: RoutedEventArgs -> unit, ?subPatchOptions) =
+            AttrBuilder<'t>.CreateSubscription<RoutedEventArgs>
+                (DragDrop.DragLeaveEvent, func, ?subPatchOptions = subPatchOptions)
+
+        static member onDragOver<'t when 't :> Control> (func: DragEventArgs -> unit, ?subPatchOptions) =
+            AttrBuilder<'t>.CreateSubscription<DragEventArgs>
+                (DragDrop.DragOverEvent, func, ?subPatchOptions = subPatchOptions)
+
+        static member onDrop<'t when 't :> Control> (func: DragEventArgs -> unit, ?subPatchOptions) =
+            AttrBuilder<'t>.CreateSubscription<DragEventArgs>
+                (DragDrop.DropEvent, func, ?subPatchOptions = subPatchOptions)
+
+        static member allowDrop<'t when 't :> Control> (allow: bool): IAttr<'t> =
+            AttrBuilder<'t>.CreateProperty<bool> (DragDrop.AllowDropProperty, allow, ValueNone)


### PR DESCRIPTION
This adds Drag & Drop support to FuncUI and ports the C# Avalonia Drag+Drop demo to F#.

As mentioned on gitter, when you click on the drag source, onPointerPressed it triggered twice.  I am uncertain if this is a bug in my code, or a bug in Avalonia or FuncUI.

The final commit below has an ugly hack to workaround this.