### PR TITLE
Controlled Components

### DIFF
--- a/src/Avalonia.FuncUI.DSL/Avalonia.FuncUI.DSL.fsproj
+++ b/src/Avalonia.FuncUI.DSL/Avalonia.FuncUI.DSL.fsproj
@@ -25,6 +25,9 @@
         <Compile Include="Base\ContentPresenter.fs" />
         <Compile Include="Base\Animatable.fs" />
         <Compile Include="Base\RenderOptions.fs" />
+        <Compile Include="Controls\Helpers.fs" />
+
+        <Compile Include="Controls\ControlledTextBox.fs" />
 
         <Compile Include="Primitives\TemplatedControl.fs" />
         <Compile Include="Primitives\HeaderedContentControl.fs" />
@@ -105,6 +108,7 @@
         <Compile Include="TabControl.fs" />
         <Compile Include="TabItem.fs" />
         <Compile Include="ViewBox.fs" />
+        <Compile Include="ControlledTextBox.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Avalonia.FuncUI.DSL/ControlledTextBox.fs
+++ b/src/Avalonia.FuncUI.DSL/ControlledTextBox.fs
@@ -1,0 +1,32 @@
+﻿namespace Avalonia.FuncUI.DSL
+
+open Avalonia.FuncUI.Controls
+open Avalonia.FuncUI.DSL
+open Avalonia.Input
+
+[<AutoOpen>]
+module ControlledTextBox =
+    open Avalonia
+    open Avalonia.Controls
+    open Avalonia.Media    
+    open Avalonia.FuncUI.Builder
+    open Avalonia.FuncUI.Types
+    
+    let create (attrs: IAttr<ControlledTextBox> list): IView<ControlledTextBox> =
+        ViewBuilder.Create<ControlledTextBox>(attrs)
+        
+    type ControlledTextBox with
+    
+        static member value<'t when 't :> ControlledTextBox> str =
+            let getter : 't -> string = fun c -> c.Text
+            let setter : ('t * string) -> unit = (fun (c, v) -> v |> c.MutateControlledValue)
+            
+            AttrBuilder<'t>.CreateProperty<string>("Value", str, ValueSome getter, ValueSome setter, ValueNone)
+            
+        static member onChange<'t when 't :> ControlledTextBox> fn =
+            let getter : 't -> (TextInputEventArgs -> unit) = fun c -> c.OnChangeCallback
+            let setter : ('t * (TextInputEventArgs -> unit)) -> unit =
+                (fun (c, f) -> c.OnChangeCallback <- f)
+            
+            AttrBuilder<'t>.CreateProperty<TextInputEventArgs -> unit>("OnChange", fn, ValueSome getter, ValueSome setter, ValueNone)
+            

--- a/src/Avalonia.FuncUI.DSL/Controls/ControlledTextBox.fs
+++ b/src/Avalonia.FuncUI.DSL/Controls/ControlledTextBox.fs
@@ -1,0 +1,197 @@
+﻿namespace Avalonia.FuncUI.Controls
+open System
+open System.Linq
+open System.Collections.Generic
+open Avalonia
+open Avalonia.Controls
+open Avalonia.Input
+open Avalonia.Input.Platform
+open Avalonia.Interactivity
+open Avalonia.Styling
+
+[<Struct>]
+type State = { Text: string; CaretIdx: int }
+
+type ControlledTextBox() =
+    inherit TextBox()    
+
+    let sort a b =
+        (min a b, max a b)
+    
+    let withoutSelection selectionStart selectionEnd str =
+        if selectionStart = selectionEnd
+        then { Text = str; CaretIdx = selectionStart }
+        else
+        let (min, max) = sort selectionStart selectionEnd
+        { Text = str.Substring(0, min) + str.Substring(max); CaretIdx = min }
+        
+    let injectAtIdx idx str input =
+        let len = String.length str        
+        let txt = str.[0..idx - 1] + input + str.[idx..len]
+        { Text = txt; CaretIdx = idx + String.length input }
+        
+    let replaceSelection selectionStart selectionEnd str input =
+        let less = withoutSelection selectionStart selectionEnd str
+        injectAtIdx (less.CaretIdx) (less.Text) input
+                
+    let synthesizeTextInputEvent (e: RoutedEventArgs) txt =
+        let syntheticEvent = TextInputEventArgs()
+        syntheticEvent.Text <- txt
+        syntheticEvent.Route <- e.Route
+        syntheticEvent.Source <- e.Source
+        syntheticEvent.RoutedEvent <- e.RoutedEvent
+        syntheticEvent
+        
+    let nullStrToEmpty str =
+        match str with null -> "" | s -> s
+        
+    member val ControlledValue = "" with get, set
+    member val NextCaretIdx = 0 with get, set
+    member val OnChangeCallback : TextInputEventArgs -> unit = ignore with get, set
+    
+    member private this.IsPasswordBox () =
+        this.PasswordChar <> Unchecked.defaultof<char>
+        
+    member private this.InvokeChange (e, text, nextCaretIdx) =
+        let syntheticEvent = synthesizeTextInputEvent e text
+        
+        this.ClearSelection()
+        this.NextCaretIdx <- nextCaretIdx
+        syntheticEvent |> this.OnChangeCallback
+        syntheticEvent.Handled <- true
+        
+    member private this.HandleTextInput (e: TextInputEventArgs) =
+        let input = e.Text |> this.RemoveInvalidCharacters
+        let thisText = this.Text |> nullStrToEmpty
+        let selectionLength = Math.Abs(this.SelectionStart - this.SelectionEnd)
+        let nextLength = thisText.Length + input.Length - selectionLength
+        let invalid =
+            String.IsNullOrEmpty(input) || (this.MaxLength <> 0 && nextLength <= this.MaxLength)
+        if not invalid then do
+            let someSelection = this.SelectionStart <> this.SelectionEnd
+            let next = if someSelection
+                        then replaceSelection this.SelectionStart this.SelectionEnd thisText input
+                        else injectAtIdx this.CaretIndex thisText input
+            this.ClearSelection()
+            this.NextCaretIdx <- next.CaretIdx
+            let e' = synthesizeTextInputEvent e next.Text
+            this.OnChangeCallback e'
+            e'.Handled <- true
+    
+    override this.OnTextInput (e: TextInputEventArgs) =
+        if not e.Handled then do
+            this.HandleTextInput e
+            e.Handled <- true
+            
+    member private this.HandleDeleteSelection(e: KeyEventArgs) =
+        let next = withoutSelection this.SelectionStart this.SelectionEnd this.Text
+        let syntheticEvent = synthesizeTextInputEvent e next.Text
+        
+        this.ClearSelection()
+        this.NextCaretIdx <- this.SelectionStart
+        syntheticEvent |> this.OnChangeCallback
+        syntheticEvent.Handled <- true
+            
+    member private this.HandleCut(e: KeyEventArgs) =
+        let someSelection = this.SelectionStart <> this.SelectionEnd
+        if someSelection then do
+            this.Copy()
+            this.HandleDeleteSelection(e)       
+            
+    member private this.HandlePaste(e: KeyEventArgs) =
+        let service = AvaloniaLocator.Current.GetService<IClipboard>()
+        let text = service.GetTextAsync() |> Async.AwaitTask |> Async.RunSynchronously
+        let syntheticEvent = synthesizeTextInputEvent e text
+        do this.HandleTextInput syntheticEvent
+        
+    member private this.HandleCtrlBackspace(e: KeyEventArgs) =
+        let text = this.Text.Substring(this.CaretIndex)
+        do this.InvokeChange (e, text, 0)
+                
+    member private this.HandleBackspace(e: KeyEventArgs) =
+        let shouldCleanupDanglingReturn =
+            this.CaretIndex > 1 &&
+            this.Text.[this.CaretIndex - 1] = '\n' &&
+            this.Text.[this.CaretIndex - 2] = '\r'
+        let removeCt = if shouldCleanupDanglingReturn then 2 else 1
+        let text = this.Text.Substring(0, this.CaretIndex - removeCt) +
+                   this.Text.Substring(this.CaretIndex)        
+        do this.InvokeChange (e, text, (this.CaretIndex - removeCt))
+    
+    member private this.HandleCtrlDelete(e: KeyEventArgs) =
+        let text = this.Text.Substring(0, this.CaretIndex)
+        do this.InvokeChange (e, text, text.Length)
+        
+    member private this.HandleDelete(e: KeyEventArgs) =
+        let shouldCleanupDanglingReturn =
+            this.CaretIndex < this.Text.Length - 1 &&
+            this.Text.[this.CaretIndex + 1] = '\n' &&
+            this.Text.[this.CaretIndex] = '\r'
+        let removeCt = if shouldCleanupDanglingReturn then 2 else 1
+        let text = this.Text.Substring(0, this.CaretIndex) +
+                   this.Text.Substring(this.CaretIndex + removeCt)        
+        do this.InvokeChange (e, text, this.CaretIndex)
+        
+    member private this.HandleTab(e: KeyEventArgs) =
+        let syntheticEvent = synthesizeTextInputEvent e "\t"
+        do this.HandleTextInput syntheticEvent
+        
+    member private this.HandleReturn(e: KeyEventArgs) =
+        let syntheticEvent = synthesizeTextInputEvent e this.NewLine
+        do this.HandleTextInput syntheticEvent
+        
+    member this.HandleUndo(e: KeyEventArgs) =
+        
+        ()
+        
+    // This OnKeyDown override intercepts cases which would result in this.Text being mutated.
+    // In these cases, non-destructive handlers pass the event to this.OnChangeCallback.
+    // Outside of these cases, this override forwards the event to the base TextBox implementation. 
+    override this.OnKeyDown (e: KeyEventArgs) =
+        let keymap = AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>()
+        let matches (gestures: List<KeyGesture>) =
+            gestures.Any(fun g -> g.Matches e)
+        let isPw = this.IsPasswordBox()
+        let someSelection = this.SelectionStart <> this.SelectionEnd
+        let modifiers = e.KeyModifiers
+        let hasWholeWordModifiers = modifiers.HasFlag(keymap.WholeWordTextActionModifiers);
+        
+        // TODO: Undo redo state
+        if (matches keymap.Cut && not isPw) then
+            this.HandleCut(e)
+            e.Handled <- true
+        elif (matches keymap.Paste) then
+            this.HandlePaste(e)
+            e.Handled <- true
+        elif (e.Key = Key.Back) then
+            if someSelection then
+                this.HandleDeleteSelection(e)
+            elif this.CaretIndex > 0 then
+                if hasWholeWordModifiers
+                then do this.HandleCtrlBackspace(e)
+                else do this.HandleBackspace(e)
+            e.Handled <- true
+        elif (e.Key = Key.Delete) then            
+            if someSelection then
+                this.HandleDeleteSelection(e)
+            elif this.CaretIndex < this.Text.Length - 1 then
+                if hasWholeWordModifiers
+                then do this.HandleCtrlDelete(e)
+                else do this.HandleDelete(e)
+            e.Handled <- true
+        elif (e.Key = Key.Enter && this.AcceptsReturn) then
+            this.HandleReturn(e)
+            e.Handled <- true
+        elif (e.Key = Key.Tab && this.AcceptsTab) then
+            this.HandleTab(e)
+            e.Handled <- true
+        else do
+            base.OnKeyDown(e)   
+        ()                
+        
+    member this.MutateControlledValue str =
+        this.Text <- str
+        this.CaretIndex <- this.NextCaretIdx
+                
+    interface IStyleable with
+        member this.StyleKey = typeof<TextBox>

--- a/src/Avalonia.FuncUI.DSL/Controls/Helpers.fs
+++ b/src/Avalonia.FuncUI.DSL/Controls/Helpers.fs
@@ -1,0 +1,39 @@
+﻿namespace Avalonia.FuncUI.DSL.Controls
+
+module Helpers =
+    module ActionHistory =
+        [<Struct>]
+        type ActionHistory<'t> =
+            { past: 't list
+              present: 't
+              future: 't list
+              limit: int }
+            
+        let init t limit = { past = []; present = t; future = []; limit = limit }
+        
+        let setLimit ah l = { ah with limit = l }
+        
+        let push t ah =
+            let past =
+                if List.length ah.past = ah.limit
+                    then ah.present::(ah.past |> List.take (ah.limit - 1))
+                    else ah.present::ah.past
+            { ah with present = t; past = past; future = [] }
+                
+        let undo ah =
+            let futureCapped = (List.length ah.future) = ah.limit
+            match (ah.past, futureCapped) with
+            | ([], _) -> ah
+            | (t::ts, false) -> { ah with present = t; past = ts; future = ah.present::ah.future }
+            | (t::ts, true) ->
+                let future = ah.present::(ah.future |> List.take (ah.limit - 1))
+                { ah with present = t; past = ts; future = future }
+        
+        let redo ah =
+            let pastCapped = (List.length ah.past) = ah.limit
+            match (ah.future, pastCapped) with
+            | ([], _) -> ah
+            | (t::ts, false) -> { ah with present = t; past = ah.present::ah.past; future = ts }
+            | (t::ts, true) ->
+                let past = ah.present::(ah.past |> List.take (ah.limit - 1))
+                { ah with present = t; past = past; future = ts }

--- a/src/Avalonia.FuncUI.sln
+++ b/src/Avalonia.FuncUI.sln
@@ -29,6 +29,8 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Examples.Presso", "Examples
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Examples.MusicPlayer", "Examples\Examples.MusicPlayer\Examples.MusicPlayer.fsproj", "{C9BF89F2-6DE8-4F37-A6AD-6D40E982F265}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Examples.ControlledComponents", "Examples\Examples.ControlledComponents\Examples.ControlledComponents.fsproj", "{F23A44E1-3D11-4DF9-AC4B-2CDA42EF9369}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,6 +77,10 @@ Global
 		{C9BF89F2-6DE8-4F37-A6AD-6D40E982F265}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C9BF89F2-6DE8-4F37-A6AD-6D40E982F265}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C9BF89F2-6DE8-4F37-A6AD-6D40E982F265}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F23A44E1-3D11-4DF9-AC4B-2CDA42EF9369}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F23A44E1-3D11-4DF9-AC4B-2CDA42EF9369}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F23A44E1-3D11-4DF9-AC4B-2CDA42EF9369}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F23A44E1-3D11-4DF9-AC4B-2CDA42EF9369}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -87,6 +93,7 @@ Global
 		{1401B46D-1F14-4D29-8E45-96E62D46405F} = {F6F4AAF7-2BDA-4D2F-B78D-F6D8A03F660E}
 		{7A0CA9E2-AFB8-4BA0-A725-F80EB98717C4} = {F6F4AAF7-2BDA-4D2F-B78D-F6D8A03F660E}
 		{C9BF89F2-6DE8-4F37-A6AD-6D40E982F265} = {F6F4AAF7-2BDA-4D2F-B78D-F6D8A03F660E}
+		{F23A44E1-3D11-4DF9-AC4B-2CDA42EF9369} = {F6F4AAF7-2BDA-4D2F-B78D-F6D8A03F660E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4630E817-6780-4C98-9379-EA3B45224339}

--- a/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
+++ b/src/Avalonia.FuncUI/Avalonia.FuncUI.fsproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="0.10.0-rc1" />
     <PackageReference Update="FSharp.Core" Version="4.7.2" />
+    <PackageReference Include="FSharp.Control.Reactive" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Examples/Examples.ControlledComponents/ControlledDemo.fs
+++ b/src/Examples/Examples.ControlledComponents/ControlledDemo.fs
@@ -1,0 +1,102 @@
+﻿namespace Examples.ControlledComponents
+
+open System.Text.RegularExpressions
+open Avalonia.FuncUI.DSL
+open Avalonia.FuncUI.Controls
+open Avalonia.FuncUI.DSL
+
+module ControlledDemo =
+    open Avalonia.Controls
+    open Avalonia.Layout
+    
+    type State = { maskedString : string; pickerString : string; changeCt : int }
+    let init = { maskedString = ""; pickerString = "A"; changeCt = 0 }
+
+    type Msg =
+    | SetMaskedString of string
+    | SetPickerString of string
+    | IncrChange
+
+    let update (msg: Msg) (state: State) : State =
+        match msg with
+        | SetMaskedString str -> { state with maskedString = str }
+        | SetPickerString str -> { state with pickerString = str }
+        | IncrChange -> { state with changeCt = state.changeCt + 1 }
+        
+    let mask = @"[^aeiouAEIOU]"
+    let noVowels = String.filter (fun c -> Regex.IsMatch(string c, mask))
+    
+    let labelTextBoxView header onChange value =
+        DockPanel.create [
+            DockPanel.dock Dock.Top
+            DockPanel.horizontalAlignment HorizontalAlignment.Stretch
+            DockPanel.children [
+                TextBlock.create [
+                    TextBlock.text header
+                    TextBlock.dock Dock.Top
+                    TextBlock.horizontalAlignment HorizontalAlignment.Stretch
+                ]
+                ControlledTextBox.create [
+                    TextBox.dock Dock.Top
+                    TextBox.horizontalAlignment HorizontalAlignment.Stretch
+                    ControlledTextBox.onChange onChange
+                    ControlledTextBox.value value
+                ]
+            ]
+        ]
+        
+    let picker value onChange  =
+        DockPanel.create [
+            DockPanel.dock Dock.Top
+            DockPanel.horizontalAlignment HorizontalAlignment.Stretch
+            DockPanel.children [
+                TextBlock.create [
+                    TextBlock.text "Picker: Update value without extra messages dispatched"
+                    TextBlock.dock Dock.Top
+                    TextBlock.horizontalAlignment HorizontalAlignment.Stretch
+                ]
+                StackPanel.create [
+                    StackPanel.horizontalAlignment HorizontalAlignment.Stretch
+                    StackPanel.children [
+                        Button.create [
+                            Button.content "A"
+                            Button.onClick (fun _ -> onChange "A")
+                        ]
+                        Button.create [
+                            Button.content "B"
+                            Button.onClick (fun _ -> onChange "B")
+                        ]
+                        Button.create [
+                            Button.content "C"
+                            Button.onClick (fun _ -> onChange "C")
+                        ]
+                    ]
+                ]
+                ControlledTextBox.create [
+                    TextBox.horizontalAlignment HorizontalAlignment.Stretch
+                    ControlledTextBox.onChange (fun e -> onChange e.Text)
+                    ControlledTextBox.value value
+                ]
+            ]
+        ]
+    
+    let view (state: State) (dispatch) =
+        DockPanel.create [
+            DockPanel.children [
+                labelTextBoxView
+                    "Masked input: Filters vowels"
+                    (fun e -> e.Text |> noVowels |> SetMaskedString |> dispatch)
+                    state.maskedString
+                labelTextBoxView
+                    "Change counter: Counts onChange events received"
+                    (fun _ -> IncrChange |> dispatch)
+                    (string state.changeCt)
+                DockPanel.create [
+                    DockPanel.dock Dock.Bottom
+                    DockPanel.horizontalAlignment HorizontalAlignment.Stretch
+                    DockPanel.children [
+                        picker state.pickerString (SetPickerString >> dispatch)
+                    ]
+                ]                
+            ]
+        ]

--- a/src/Examples/Examples.ControlledComponents/Examples.ControlledComponents.fsproj
+++ b/src/Examples/Examples.ControlledComponents/Examples.ControlledComponents.fsproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net5.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Avalonia.FuncUI.DSL\Avalonia.FuncUI.DSL.fsproj" />
+        <ProjectReference Include="..\..\Avalonia.FuncUI.Elmish\Avalonia.FuncUI.Elmish.fsproj" />
+        <ProjectReference Include="..\..\Avalonia.FuncUI\Avalonia.FuncUI.fsproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Avalonia.Desktop" Version="0.10.0-rc1" />
+        <PackageReference Update="FSharp.Core" Version="4.7.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Include="ControlledDemo.fs" />
+      <Compile Include="Program.fs" />
+    </ItemGroup>
+
+</Project>

--- a/src/Examples/Examples.ControlledComponents/Library.fs
+++ b/src/Examples/Examples.ControlledComponents/Library.fs
@@ -1,0 +1,70 @@
+﻿namespace Examples.CounterApp
+
+open Avalonia.FuncUI.DSL
+
+module Counter =
+    open Avalonia.Controls
+    open Avalonia.Layout
+    
+    type State = { count : int }
+    let init = { count = 0 }
+
+    type Msg =
+    | Increment
+    | Decrement
+    | SetCount of int
+    | Reset 
+
+    let update (msg: Msg) (state: State) : State =
+        match msg with
+        | Increment -> { state with count = state.count + 1 }
+        | Decrement -> { state with count = state.count - 1 }
+        | SetCount count  -> { state with count = count } 
+        | Reset -> init
+    
+    let view (state: State) (dispatch) =
+        DockPanel.create [
+            DockPanel.children [
+                Button.create [
+                    Button.dock Dock.Bottom
+                    Button.onClick (fun _ -> dispatch Reset)
+                    Button.content "reset"
+                    Button.horizontalAlignment HorizontalAlignment.Stretch
+                ]                
+                Button.create [
+                    Button.dock Dock.Bottom
+                    Button.onClick (fun _ -> dispatch Decrement)
+                    Button.content "-"
+                    Button.horizontalAlignment HorizontalAlignment.Stretch
+                ]
+                Button.create [
+                    Button.dock Dock.Bottom
+                    Button.onClick (fun _ -> dispatch Increment)
+                    Button.content "+"
+                    Button.horizontalAlignment HorizontalAlignment.Stretch
+                ]
+                Button.create [
+                    Button.dock Dock.Bottom
+                    Button.onClick ((fun _ -> state.count * 2 |> SetCount |> dispatch), SubPatchOptions.OnChangeOf state.count)
+                    Button.content "x2"
+                    Button.horizontalAlignment HorizontalAlignment.Stretch
+                ]
+                TextBox.create [
+                    TextBox.dock Dock.Bottom
+                    TextBox.onTextChanged ((fun text ->
+                        let isNumber, number = System.Int32.TryParse text
+                        if isNumber then
+                            number |> SetCount |> dispatch) 
+                    )
+                    TextBox.text (string state.count)
+                    TextBox.horizontalAlignment HorizontalAlignment.Stretch
+                ]
+                TextBlock.create [
+                    TextBlock.dock Dock.Top
+                    TextBlock.fontSize 48.0
+                    TextBlock.verticalAlignment VerticalAlignment.Center
+                    TextBlock.horizontalAlignment HorizontalAlignment.Center
+                    TextBlock.text (string state.count)
+                ]
+            ]
+        ]

--- a/src/Examples/Examples.ControlledComponents/Program.fs
+++ b/src/Examples/Examples.ControlledComponents/Program.fs
@@ -1,0 +1,46 @@
+﻿namespace Examples.ControlledComponents
+
+open Avalonia
+open Avalonia.Themes.Fluent
+open Elmish
+open Avalonia.FuncUI.Components.Hosts
+open Avalonia.FuncUI
+open Avalonia.FuncUI.Elmish
+open Avalonia.Controls.ApplicationLifetimes
+
+type MainWindow() as this =
+    inherit HostWindow()
+    do
+        base.Title <- "Controlled Components Example"
+        base.Height <- 200.0
+        base.Width <- 400.0    
+      
+        //this.VisualRoot.VisualRoot.Renderer.DrawFps <- true
+        //this.VisualRoot.VisualRoot.Renderer.DrawDirtyRects <- true
+        Elmish.Program.mkSimple (fun () -> ControlledDemo.init) ControlledDemo.update ControlledDemo.view
+        |> Program.withHost this
+        |> Program.withConsoleTrace
+        |> Program.run
+        
+type App() =
+    inherit Application()
+
+    override this.Initialize() =
+        this.Styles.Add (FluentTheme(baseUri = null, Mode = FluentThemeMode.Dark))
+
+    override this.OnFrameworkInitializationCompleted() =
+        match this.ApplicationLifetime with
+        | :? IClassicDesktopStyleApplicationLifetime as desktopLifetime ->
+            let mainWindow = MainWindow()
+            desktopLifetime.MainWindow <- mainWindow
+        | _ -> ()
+
+module Program =
+
+    [<EntryPoint>]
+    let main(args: string[]) =
+        AppBuilder
+            .Configure<App>()
+            .UsePlatformDetect()
+            .UseSkia()
+            .StartWithClassicDesktopLifetime(args)


### PR DESCRIPTION
This pull request contains a proof-of-concept for 'controlled components', a feature where FuncUI is the single source of truth for a component's value.

### What is this
In Avalonia, controls usually maintain their own internal state via AvaloniaProperty getters and setters. This internal state gets updated by either user input or setters in code. In FuncUI, the value of a control is dictated by state. We can combine these two by making the FuncUI state 'the single source of truth', so that the content of the Avalonia control _always_ reflects the provided state value.

### Motivation
When Avalonia controls have their own internal state, they can easily become de-synced with the state provided by the MVU framework. Consider the existing CounterApp example:

![image](https://user-images.githubusercontent.com/12357846/105562896-e6333280-5cd0-11eb-9176-24add993cb88.png)

This app only dispatches a change event if the control's value successfully parses as a number. If not, the Avalonia control's state becomes out-of-sync with the Counter state. With a controlled component, the input field's text will _always_ reflect state as given by FuncUI. This has immediate benefits:

- The app behaves more predictably. Instead of querying the underlying control to get its de-synced value, the author can be confident that it will be a pure reflection of state.
- The app dispatches fewer messages. Currently, FuncUI will dispatch change events for both user input _and_ for changes made by code setters. By controlling the component directly, we can dispatch on user input _without_ dispatching redundant messages for changes made by the framework itself.
- Other state transformations become much easier to implement. For example, masking an input (see #80) can be done purely through the MVU structure without any further customization. This can apply to any kind of arbitrary state projection. This PR contains some examples of this.

### Implementation
By default, Avalonia controls will mutate their own values in response to user input. To implement controlled components, we need to defer mutation until the value comes back via the framework. As a proof-of-concept, this PR contains a ControlledTextBox control which overrides the destructive methods of Avalonia's existing TextBox control. 

All mutation happens in a single method, which is invoked by the framework only after it receives a new value from the view function. The app author receives a synthesized event with text set to a kind of 'staged' change. Then, the app author can decide if they want to accept, reject, or modify this value before putting it into state.

I would like to implement Controlled variants for all user-input components. I implemented this proof-of-concept with the TextBox, which has a lot of different kinds of user input, as well as other kinds of state (the selection and the caret position remain 'uncontrolled'). Other controls probably involve less code.

### Next steps
- Need to implement Undo/Redo mutations still. This PR contains a small helper for action history which I was considering (Avalonia's internal UndoRedoHelper is private) but I wanted to leave this up for discussion some before pursuing it further.
- Should consider the names of the APIs. Prepending 'Controlled' to the front of things seems like a lot of characters. Currently the new properties are called 'value' and 'onChange'.
- This implementation has a fair amount of overriding the basic control. We could consider reaching out to Avalonia maintainers to see if their implementation could become more friendly to this kind of 'deferred mutation'.

### Prior art
[Controlled components in React](https://reactjs.org/docs/forms.html#controlled-components)